### PR TITLE
feat(playground): colored text in console

### DIFF
--- a/playground/.prettierignore
+++ b/playground/.prettierignore
@@ -1,0 +1,3 @@
+library-code.js
+minified-lib.js
+pnpm-lock.yaml

--- a/playground/components/console.tsx
+++ b/playground/components/console.tsx
@@ -6,7 +6,7 @@ import { useOutputStore } from "@/store";
 import { ScrollArea, ScrollBar } from "./ui/scroll-area";
 import { useColoredTextStore } from "@/store";
 import React from "react";
-import {detectColor} from "@/lib/detectColor";
+import { detectColor } from "@/lib/detectColor";
 
 const geistSans = localFont({
   src: "../app/fonts/GeistVF.woff",
@@ -26,30 +26,30 @@ export function Console() {
       let lineCopy = line;
       const colors = [] as string[]; // Stores all the colors in the line
 
-      while(nextColor) {
-       const detected = detectColor(lineCopy);
-       if (detected) {
-        const color = detected[0];
-        colors.push(color);
-        lineCopy = lineCopy.replaceAll(color, "");
-       } else {
+      while (nextColor) {
+        const detected = detectColor(lineCopy);
+        if (detected) {
+          const color = detected[0];
+          colors.push(color);
+          lineCopy = lineCopy.replaceAll(color, "");
+        } else {
           nextColor = false;
         }
       }
 
       for (let i = 0; i < colors.length; i++) {
-        line = line.replaceAll(colors[i], `<span style="color:${colors[i]}">${colors[i]}</span>`);
+        line = line.replaceAll(
+          colors[i],
+          `<span style="color:${colors[i]}">${colors[i]}</span>`
+        );
       }
 
-      console.log(line)
-
-      formatted = <span dangerouslySetInnerHTML={{__html: line}} />;
-      
+      formatted = <span dangerouslySetInnerHTML={{ __html: line }} />;
     } else {
       formatted = <span>{line}</span>;
     }
 
-    return formatted
+    return formatted;
   }
 
   function handleNewLine(output: string) {

--- a/playground/components/console.tsx
+++ b/playground/components/console.tsx
@@ -22,21 +22,29 @@ export function Console() {
     let formatted: React.ReactNode;
 
     if (colored) {
-      const regexMatch = detectColor(line);
+      let nextColor = true;
+      let lineCopy = line;
+      const colors = [] as string[]; // Stores all the colors in the line
 
-      if (regexMatch) {
-        
-        const index = line.indexOf(regexMatch[0]);
-        const start = line.slice(0, index);
-        const end = line.slice(index + regexMatch[0].length);
-        const coloredSpan = <span style={{color: regexMatch[0]}}>{regexMatch[0]}</span>;
-        
-        formatted = <span >
-          {start}
-          {coloredSpan}
-          {end}
-        </span>;
+      while(nextColor) {
+       const detected = detectColor(lineCopy);
+       if (detected) {
+        const color = detected[0];
+        colors.push(color);
+        lineCopy = lineCopy.replaceAll(color, "");
+       } else {
+          nextColor = false;
+        }
       }
+
+      for (let i = 0; i < colors.length; i++) {
+        line = line.replaceAll(colors[i], `<span style="color:${colors[i]}">${colors[i]}</span>`);
+      }
+
+      console.log(line)
+
+      formatted = <span dangerouslySetInnerHTML={{__html: line}} />;
+      
     } else {
       formatted = <span>{line}</span>;
     }

--- a/playground/components/console.tsx
+++ b/playground/components/console.tsx
@@ -4,6 +4,8 @@ import localFont from "next/font/local";
 import { cn } from "@/lib/utils";
 import { useOutputStore } from "@/store";
 import { ScrollArea, ScrollBar } from "./ui/scroll-area";
+import { useColoredTextStore } from "@/store";
+import React from "react";
 
 const geistSans = localFont({
   src: "../app/fonts/GeistVF.woff",
@@ -13,13 +15,22 @@ const geistSans = localFont({
 
 export function Console() {
   const output = useOutputStore(state => state.output);
+  const coloredText = useColoredTextStore(state => state.colored);
+
+  function getColored(line: string, colored: boolean): React.ReactNode {
+    return (
+      <span className={`${colored ? "text-blue-500" : ""}`}>
+        Hello
+      </span>
+    )
+  }
 
   function handleNewLine(output: string) {
     return output.split("\n").map((line, index) => {
       return (
         <div key={index} className="flex items-center">
           <span className="text-neutral-500">{">"}</span>
-          <span className="ml-2">{line}</span>
+          <span className="ml-2">{getColored(line, coloredText)}</span>
         </div>
       );
     });

--- a/playground/components/console.tsx
+++ b/playground/components/console.tsx
@@ -6,6 +6,7 @@ import { useOutputStore } from "@/store";
 import { ScrollArea, ScrollBar } from "./ui/scroll-area";
 import { useColoredTextStore } from "@/store";
 import React from "react";
+import {detectColor} from "@/lib/detectColor";
 
 const geistSans = localFont({
   src: "../app/fonts/GeistVF.woff",
@@ -18,11 +19,29 @@ export function Console() {
   const coloredText = useColoredTextStore(state => state.colored);
 
   function getColored(line: string, colored: boolean): React.ReactNode {
-    return (
-      <span className={`${colored ? "text-blue-500" : ""}`}>
-        Hello
-      </span>
-    )
+    let formatted: React.ReactNode;
+
+    if (colored) {
+      const regexMatch = detectColor(line);
+
+      if (regexMatch) {
+        
+        const index = line.indexOf(regexMatch[0]);
+        const start = line.slice(0, index);
+        const end = line.slice(index + regexMatch[0].length);
+        const coloredSpan = <span style={{color: regexMatch[0]}}>{regexMatch[0]}</span>;
+        
+        formatted = <span >
+          {start}
+          {coloredSpan}
+          {end}
+        </span>;
+      }
+    } else {
+      formatted = <span>{line}</span>;
+    }
+
+    return formatted
   }
 
   function handleNewLine(output: string) {

--- a/playground/components/layout/top-bar.tsx
+++ b/playground/components/layout/top-bar.tsx
@@ -7,8 +7,9 @@ import runCode from "@/actions/run-code";
 import { useCodeStore, useOutputStore } from "@/store";
 import React from "react";
 import { LanguageInfo } from "../language-info";
-import { Toggle } from "@/components/ui/toggle"
-import {PaintBucket} from "lucide-react"
+import { Toggle } from "@/components/ui/toggle";
+import { PaintBucket } from "lucide-react";
+import { useColoredTextStore } from "@/store";
 
 const geistSans = localFont({
   src: "../../app/fonts/GeistVF.woff",
@@ -19,6 +20,9 @@ const geistSans = localFont({
 export function TopBar() {
   const code = useCodeStore(state => state.code);
   const setOutput = useOutputStore(state => state.updateOutput);
+
+  const coloredText = useColoredTextStore(state => state.colored);
+  const toggleColoredText = useColoredTextStore(state => state.toggleColored);
 
   async function handleRun() {
     const output = await runCode(code);
@@ -34,9 +38,9 @@ export function TopBar() {
         <Button variant={"secondary"} onClick={handleRun}>
           Run
         </Button>
-        <Toggle variant={"custom"}>
+        <Toggle variant={"custom"} onClick={toggleColoredText} pressed={coloredText}>
           <PaintBucket />
-        Colored text
+          Colored text
         </Toggle>
       </div>
     </div>

--- a/playground/components/layout/top-bar.tsx
+++ b/playground/components/layout/top-bar.tsx
@@ -38,7 +38,11 @@ export function TopBar() {
         <Button variant={"secondary"} onClick={handleRun}>
           Run
         </Button>
-        <Toggle variant={"custom"} onClick={toggleColoredText} pressed={coloredText}>
+        <Toggle
+          variant={"custom"}
+          onClick={toggleColoredText}
+          pressed={coloredText}
+        >
           <PaintBucket />
           Colored text
         </Toggle>

--- a/playground/components/layout/top-bar.tsx
+++ b/playground/components/layout/top-bar.tsx
@@ -7,6 +7,8 @@ import runCode from "@/actions/run-code";
 import { useCodeStore, useOutputStore } from "@/store";
 import React from "react";
 import { LanguageInfo } from "../language-info";
+import { Toggle } from "@/components/ui/toggle"
+import {PaintBucket} from "lucide-react"
 
 const geistSans = localFont({
   src: "../../app/fonts/GeistVF.woff",
@@ -32,6 +34,10 @@ export function TopBar() {
         <Button variant={"secondary"} onClick={handleRun}>
           Run
         </Button>
+        <Toggle variant={"custom"}>
+          <PaintBucket />
+        Colored text
+        </Toggle>
       </div>
     </div>
   );

--- a/playground/components/ui/toggle.tsx
+++ b/playground/components/ui/toggle.tsx
@@ -1,0 +1,46 @@
+"use client"
+
+import * as React from "react"
+import * as TogglePrimitive from "@radix-ui/react-toggle"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const toggleVariants = cva(
+  "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium transition-colors hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        outline:
+          "border border-input bg-transparent shadow-sm hover:bg-accent hover:text-accent-foreground",
+          custom:"data-[state=on]:text-yellow-400"
+      },
+      size: {
+        default: "h-9 px-2 min-w-9",
+        sm: "h-8 px-1.5 min-w-8",
+        lg: "h-10 px-2.5 min-w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+const Toggle = React.forwardRef<
+  React.ElementRef<typeof TogglePrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof TogglePrimitive.Root> &
+    VariantProps<typeof toggleVariants>
+>(({ className, variant, size, ...props }, ref) => (
+  <TogglePrimitive.Root
+    ref={ref}
+    className={cn(toggleVariants({ variant, size, className }))}
+    {...props}
+  />
+))
+
+Toggle.displayName = TogglePrimitive.Root.displayName
+
+export { Toggle, toggleVariants }

--- a/playground/components/ui/toggle.tsx
+++ b/playground/components/ui/toggle.tsx
@@ -1,20 +1,20 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as TogglePrimitive from "@radix-ui/react-toggle"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from "react";
+import * as TogglePrimitive from "@radix-ui/react-toggle";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const toggleVariants = cva(
-  "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium transition-colors hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium transition-colors text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
         default: "bg-transparent",
         outline:
           "border border-input bg-transparent shadow-sm hover:bg-accent hover:text-accent-foreground",
-          custom:"data-[state=on]:text-yellow-400"
+        custom: "data-[state=on]:text-yellow-400",
       },
       size: {
         default: "h-9 px-2 min-w-9",
@@ -27,7 +27,7 @@ const toggleVariants = cva(
       size: "default",
     },
   }
-)
+);
 
 const Toggle = React.forwardRef<
   React.ElementRef<typeof TogglePrimitive.Root>,
@@ -39,8 +39,8 @@ const Toggle = React.forwardRef<
     className={cn(toggleVariants({ variant, size, className }))}
     {...props}
   />
-))
+));
 
-Toggle.displayName = TogglePrimitive.Root.displayName
+Toggle.displayName = TogglePrimitive.Root.displayName;
 
-export { Toggle, toggleVariants }
+export { Toggle, toggleVariants };

--- a/playground/constants/index.ts
+++ b/playground/constants/index.ts
@@ -1,6 +1,6 @@
 const DEFAULT_CODE = `// Use functions directly
-const randomRgb = rgb()
-const randomHex = hex()
+const randomRgb = randomColor("rgb")
+const randomHex = randomColor("hex")
 
 // or via PigmentTS object
 const blend = PigmentTS.blendColors(randomRgb, randomHex, 0.5);

--- a/playground/constants/index.ts
+++ b/playground/constants/index.ts
@@ -1,12 +1,12 @@
 const DEFAULT_CODE = `// Use functions directly
-const rgb = randomColor("rgb")
-const hex = randomColor("hex")
+const randomRgb = rgb()
+const randomHex = hex()
 
 // or via PigmentTS object
-const blend = PigmentTS.blendColors(rgb, hex, 0.5);
+const blend = PigmentTS.blendColors(randomRgb, randomHex, 0.5);
 
-console.log("Color 1: " + rgb)
-console.log("Color 2: " + hex)
+console.log("Color 1: " + randomRgb)
+console.log("Color 2: " + randomHex)
 console.log("Blend (50%): " + blend)`;
 
 const LANGUAGE_INFO = {

--- a/playground/lib/detectColor.ts
+++ b/playground/lib/detectColor.ts
@@ -1,0 +1,20 @@
+import {Format} from "@/types/format";
+
+export function detectColor(line: string) {
+  const formats = ["rgb", "hex", "hsl", "tw", "rgba", "hsla"] as Format[];
+
+  const regex = {
+    rgb: /rgb\((\d{1,3}), (\d{1,3}), (\d{1,3})\)/,
+    hex: /#[0-9A-F]{6}$/i,
+    hsl: /hsl\((\d+),\s*([\d.]+)%,\s*([\d.]+)%\)/g,
+    tw: /(?:$|^|)(slate-|gray-|zinc-|neutral-|stone-|red-|orange-|amber-|yellow-|lime-|green-|emerald-|teal-|cyan-|sky-|blue-|indigo-|violet-|purple-|fuchsia-|pink-|rose-|white|black)(50|100|200|300|400|500|600|700|800|900|950|)(?:$|^|)/gi,
+    rgba: /rgba\((\d{1,3}), (\d{1,3}), (\d{1,3}), ([0-1](\.\d+)?)\)/,
+    hsla: /hsla\((\d+),\s*([\d.]+)%,\s*([\d.]+)%, ([0-1](\.\d+)?)\)/,
+  } as Record<string, RegExp>;
+
+  for (const format of formats)
+    if (regex[format].exec(line))
+      return regex[format].exec(line);
+
+  return null;
+}

--- a/playground/lib/detectColor.ts
+++ b/playground/lib/detectColor.ts
@@ -1,4 +1,4 @@
-import {Format} from "@/types/format";
+import { Format } from "@/types/format";
 
 export function detectColor(line: string) {
   const formats = ["rgb", "hex", "hsl", "tw", "rgba", "hsla"] as Format[];
@@ -13,8 +13,7 @@ export function detectColor(line: string) {
   } as Record<string, RegExp>;
 
   for (const format of formats)
-    if (regex[format].exec(line))
-      return regex[format].exec(line);
+    if (regex[format].exec(line)) return regex[format].exec(line);
 
   return null;
 }

--- a/playground/package.json
+++ b/playground/package.json
@@ -15,6 +15,7 @@
     "@radix-ui/react-icons": "^1.3.1",
     "@radix-ui/react-scroll-area": "^1.2.0",
     "@radix-ui/react-slot": "^1.1.0",
+    "@radix-ui/react-toggle": "^1.1.0",
     "axios": "^1.7.7",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",

--- a/playground/package.json
+++ b/playground/package.json
@@ -22,7 +22,7 @@
     "lucide-react": "^0.454.0",
     "monaco-editor": "^0.52.0",
     "next": "15.0.2",
-    "pigment-ts": "workspace:*",
+    "pigment-ts": "^0.2.7",
     "prismjs": "^1.29.0",
     "react": "^16.8 || ^17.0 || ^18.0 || ^19.0",
     "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0",

--- a/playground/store/index.ts
+++ b/playground/store/index.ts
@@ -1,4 +1,4 @@
-import { CodeState, OutputState } from "@/types/store";
+import { CodeState, ColoredTextState, OutputState } from "@/types/store";
 import { create } from "zustand";
 import { DEFAULT_CODE } from "@/constants";
 
@@ -12,4 +12,9 @@ const useOutputStore = create<OutputState>()(set => ({
   updateOutput: (newOutput: string) => set({ output: newOutput }),
 }));
 
-export { useCodeStore, useOutputStore };
+const useColoredTextStore = create<ColoredTextState>()(set => ({
+  colored: false,
+  toggleColored: () => set(state => ({ colored: !state.colored })),
+}));
+
+export { useCodeStore, useOutputStore, useColoredTextStore };

--- a/playground/types/format.ts
+++ b/playground/types/format.ts
@@ -1,0 +1,1 @@
+export type Format = "hex" | "rgb" | "hsl" | "tw" | "rgba" | "hsla";

--- a/playground/types/store.ts
+++ b/playground/types/store.ts
@@ -8,4 +8,9 @@ interface OutputState {
   updateOutput: (newOutput: string) => void;
 }
 
-export { type CodeState, type OutputState };
+interface ColoredTextState {
+  colored: boolean;
+  toggleColored: () => void;
+}
+
+export { type CodeState, type OutputState, type ColoredTextState };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,8 +154,8 @@ importers:
         specifier: 15.0.2
         version: 15.0.2(@babel/core@7.26.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       pigment-ts:
-        specifier: workspace:*
-        version: link:..
+        specifier: ^0.2.7
+        version: 0.2.7
       prismjs:
         specifier: ^1.29.0
         version: 1.29.0
@@ -3810,6 +3810,9 @@ packages:
   pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
+
+  pigment-ts@0.2.7:
+    resolution: {integrity: sha512-f/0cUmZ1KWT9MOtY+OilCZCFPyh7EG4rEEp4bk/5nMKeOhb/eLjkxfaFneCPwUmj8oKaHsiMKk7RPqbB3qxxgg==}
 
   pirates@4.0.6:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
@@ -9159,6 +9162,8 @@ snapshots:
   picomatch@4.0.2: {}
 
   pify@2.3.0: {}
+
+  pigment-ts@0.2.7: {}
 
   pirates@4.0.6: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.1.0
         version: 1.1.0(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-toggle':
+        specifier: ^1.1.0
+        version: 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       axios:
         specifier: ^1.7.7
         version: 1.7.7
@@ -1590,6 +1593,19 @@ packages:
 
   '@radix-ui/react-tabs@1.1.1':
     resolution: {integrity: sha512-3GBUDmP2DvzmtYLMsHmpA1GtR46ZDZ+OreXM/N+kkQJOPIgytFWWTfDQmBQKBvaFS0Vno0FktdbVzN28KGrMdw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle@1.1.0':
+    resolution: {integrity: sha512-gwoxaKZ0oJ4vIgzsfESBuSgJNdc0rv12VhHgcqN0TEJmmZixXG/2XpsLK8kzNWYcnaoRIEEQc0bEi3dIvdUpjw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -6230,6 +6246,17 @@ snapshots:
       '@radix-ui/react-presence': 1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-roving-focus': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.12)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.12
+      '@types/react-dom': 18.3.1
+
+  '@radix-ui/react-toggle@1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.12)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)


### PR DESCRIPTION
<!-- Thank you for contributing -->

#### Purpose of the Pull Request

- [ ] Core library change
- [ ] Documentation website change
- [x] Playground website change
- [ ] Bug fix
- [ ] Other (please explain)

#### Changes made

Adds a toggle "Colored Text" above the console to change the font color of the color text (ex. #efefef)

If the toggle is pressed, then all the text written in the console will changes it's font color to respective colors.

#### Note (optional)

N/A

#### Guidelines

- [x] I have read the [contributing guidelines](https://github.com/Jay-Karia/pigment-ts/blob/main/CONTRIBUTING.md).